### PR TITLE
Upgrade gitlab-time-tracker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "electron-compile": "^6.4.2",
     "electron-log": "^3.0.0-beta4",
     "electron-squirrel-startup": "^1.0.0",
-    "gitlab-time-tracker": "^1.7.37",
+    "gitlab-time-tracker": "^1.7.40",
     "moment": "^2.20.1",
     "raven": "^2.6.2",
     "write-yaml": "^1.0.0"


### PR DESCRIPTION
Just explicitly updating the gitlab-time-tracker dependency

The latest Windows build for this app (v0.3.10) appears to be broken, due to [https://github.com/kriskbx/gitlab-time-tracker/issues/84](https://github.com/kriskbx/gitlab-time-tracker/issues/84)

Pulling in most up-to-date gitlab-time-tracker dependency (v1.7.40) and building for Windows appears to work. Provided test build at [https://github.com/changingday/gitlab-time-tracker-taskbar/releases/tag/v0.3.10.1](https://github.com/changingday/gitlab-time-tracker-taskbar/releases/tag/v0.3.10.1) which is working smoothly for me!

Just for anyone else who might be trying to install this on Windows anyway is a shame to get caught up on that one issue - this is a really useful app! Sorry to see this now appears to be unmaintained, but thanks for building it in any case!